### PR TITLE
Staging/selfmon operational fixes + Noyo data-collection proposal

### DIFF
--- a/config/scripts/attach-remotes.sh
+++ b/config/scripts/attach-remotes.sh
@@ -61,13 +61,26 @@ TYPE="${INSTANCE%-staging}"
 TYPE="${TYPE%-prod}"
 
 case "${TYPE}" in
-    water|septic|noyo|watershop-selfmon)
-        # Producer (and selfmon): push-mirror this pond to its own bucket.
+    water|septic|noyo)
+        # Producer: push-mirror this pond to its own bucket.
         echo "[attach] ${INSTANCE}: backup add origin ${S3_URL}"
         pond backup add origin "${S3_URL}" "${s3_opts[@]}" --overwrite
         # Seed the remote with the pond_init bundle so consumers (site)
         # can pull immediately, before the first data-collection tick.
         pond push origin
+        ;;
+    watershop-selfmon)
+        # selfmon is local-experimental and deliberately has NO backup
+        # remote.  run-selfmon.sh maintains it with `--prune
+        # --allow-no-remote`, which aggressively vacuums local history
+        # every tick; that is fundamentally incompatible with a push
+        # backup, because the post-commit auto-push then tries to read
+        # files the prune already deleted and fails, and the concurrent
+        # push holds the control write.lock so the next maintain cannot
+        # compact -- which lets the delta log grow until resolving
+        # /logs/journal exceeds the DataFusion memory pool and the pond
+        # wedges.  Attaching no remote keeps maintenance lock-free.
+        echo "[attach] ${INSTANCE}: local-experimental, no backup remote"
         ;;
     site)
         # Consumer: cross-pond import each producer's bucket read-through

--- a/config/scripts/measure-pond.sh
+++ b/config/scripts/measure-pond.sh
@@ -35,6 +35,20 @@ if [ ! -f "${ENV_FILE}" ]; then
     exit 1
 fi
 
+# Select the systemd unit prefix for this pond's liveness probes.  The
+# selfmon pond runs under pond-selfmon@<instance>.{timer,service} while
+# every container pond runs under pond@<name>.{timer,service}.
+# run-selfmon.sh exports SELFMON_INSTANCE with its own instance name so
+# this probe targets the correct units when it measures the selfmon pond
+# itself.  Any other pond, or an unset SELFMON_INSTANCE, uses pond@.
+# Without this the selfmon pond's own status card read timer.active from
+# a nonexistent pond@<instance>.timer and was perpetually classified red.
+if [ "${POND_NAME}" = "${SELFMON_INSTANCE:-}" ]; then
+    UNIT_PREFIX="pond-selfmon@"
+else
+    UNIT_PREFIX="pond@"
+fi
+
 # Source env file.  The probed pond's env, NOT the selfmon pond's.
 # We need POND (the storage path) to find this pond's data.
 (
@@ -44,13 +58,9 @@ fi
     # shellcheck disable=SC1090
     source "${ENV_FILE}"
     set +a
-    # SELFMON leaks in from run-selfmon.sh (which sources the selfmon
-    # env with `set -a`).  measure-pond.sh is only ever called for
-    # non-selfmon ponds (the selfmon pond is the inlined `_self`
-    # block in run-selfmon.sh) so SELFMON has no meaning here, and
-    # leaving it set causes us to look up `pond-selfmon@<name>.*`
-    # systemd units below, which do not exist for water-prod etc.
-    unset SELFMON
+    # Systemd unit selection uses UNIT_PREFIX, computed above from
+    # SELFMON_INSTANCE, so the leaked SELFMON marker from the selfmon
+    # env is no longer consulted here.
 
     : "${POND:?POND must be set in ${ENV_FILE}}"
 
@@ -133,10 +143,12 @@ fi
     # Stored in bytes (see config/semconv/duckpond-pond.yaml: unit By).
     # Source line emitted by pond CLI to stderr at process exit:
     #   "Peak memory usage: NN.NN MB"
-    # Containerized ponds run via `pond@.service`.  (The selfmon pond
-    # itself runs via `pond-selfmon@.service` but is measured by the
-    # `_self` block in run-selfmon.sh, not by this script.)
-    UNIT="pond@${POND_NAME}.service"
+    # Container ponds run via pond@<name>.service; the selfmon pond runs
+    # via pond-selfmon@<instance>.service.  UNIT_PREFIX selects the right
+    # one.  The _self block in run-selfmon.sh contributes selfmon-only
+    # metrics such as read.seconds and sitegen.seconds; this script still
+    # probes the selfmon pond for the generic size, txn, and timer rows.
+    UNIT="${UNIT_PREFIX}${POND_NAME}.service"
     PEAK_RSS_BYTES=$(journalctl --user -u "${UNIT}" \
         --no-pager -n 200 --since "5 minutes ago" 2>/dev/null \
         | grep -oE 'Peak memory usage: [0-9.]+ MB' \
@@ -168,8 +180,8 @@ fi
     #   last_run.seconds_ago   wall-clock seconds since the service's
     #                          most recent ExecMainExitTimestamp; -1
     #                          if the service has never run.
-    TIMER_UNIT="pond@${POND_NAME}.timer"
-    SERVICE_UNIT="pond@${POND_NAME}.service"
+    TIMER_UNIT="${UNIT_PREFIX}${POND_NAME}.timer"
+    SERVICE_UNIT="${UNIT_PREFIX}${POND_NAME}.service"
 
     if [ "$(systemctl --user is-active "${TIMER_UNIT}" 2>/dev/null)" = active ]; then
         TIMER_ACTIVE=1

--- a/config/scripts/pond.sh
+++ b/config/scripts/pond.sh
@@ -30,14 +30,23 @@ case "$(uname -m)" in
 esac
 
 # Image selection: staging uses latest, prod uses the promoted image.
-# Both are mutable tags pulled with --pull=newer, so `systemctl restart`
-# (or the next timer tick) picks up new images automatically.
+# Both are mutable tags.  run.sh refreshes the image once per timer tick via
+# `pond.sh <instance> --pull-image`; the individual `podman run` invocations
+# below use --pull=missing so they reuse the already-pulled local image instead
+# of each re-checking the registry (which GHCR counts as a download).
 if [[ "${INSTANCE}" == *-staging ]]; then
     IMAGE="ghcr.io/jmacd/duckpond/duckpond:latest-${ARCH}"
 else
     IMAGE="ghcr.io/jmacd/duckpond/duckpond:prod-${ARCH}"
 fi
-PULL="--pull=newer"
+
+# One-shot image refresh: fetch the mutable tag once (a single registry check)
+# so the per-command runs in this tick can use --pull=missing.
+if [ "${1:-}" = "--pull-image" ]; then
+    exec podman pull "${IMAGE}"
+fi
+
+PULL="--pull=missing"
 
 # Volume name from env file (POND_VOLUME)
 VOLUME="${POND_VOLUME:-pond-${INSTANCE}}"

--- a/config/scripts/run-selfmon.sh
+++ b/config/scripts/run-selfmon.sh
@@ -32,6 +32,13 @@ fi
 : "${POND:?POND must be set in ${ENV_FILE}}"
 export POND
 
+# Expose the selfmon instance name to measure-pond.sh so its self-probe
+# selects the pond-selfmon@ systemd units instead of the pond@ units used
+# by container ponds.  Without this the selfmon pond's own status card
+# reads timer.active from a nonexistent pond@<instance>.timer and is
+# perpetually classified red.
+export SELFMON_INSTANCE="${INSTANCE}"
+
 # ── Pre-tick maintain: trim the delta log BEFORE anything reads it ──
 # This is the ONLY maintain per tick, and it runs FIRST on purpose.
 # Every commit appends an uncheckpointed entry to the Delta log; listing

--- a/config/scripts/run-selfmon.sh
+++ b/config/scripts/run-selfmon.sh
@@ -32,6 +32,43 @@ fi
 : "${POND:?POND must be set in ${ENV_FILE}}"
 export POND
 
+# ── Pre-tick maintain: trim the delta log BEFORE anything reads it ──
+# This is the ONLY maintain per tick, and it runs FIRST on purpose.
+# Every commit appends an uncheckpointed entry to the Delta log; listing
+# or resolving /logs/journal re-reads all of them through a DataFusion
+# external sort.  When maintain ran LAST instead, a single out-of-memory
+# abort under `set -e` skipped it, so uncheckpointed versions accumulated
+# across ticks until that sort exceeded the memory pool and every tick
+# wedged permanently on the first read.  Running maintain first checkpoints
+# the log so the rest of this tick reads a small checkpoint; the handful of
+# versions this tick then appends before sitegen reads are trimmed by the
+# next tick's pass.  A failure here is non-fatal so the tick still proceeds
+# and retries next minute.
+#
+# --compact runs every tick on purpose.  The control table gains one
+# small record-parquet per control commit and is otherwise NEVER merged:
+# post-commit auto-maintain and a plain `pond maintain` both pass
+# compact=false, so without per-tick compaction its add-file count grows
+# without bound and every force=true checkpoint must re-list all of them,
+# bloating {POND}/control to many GB of checkpoint parquets.  Compacting
+# each tick keeps the control add-file count -- and therefore checkpoint
+# size -- bounded, which also keeps default log retention harmless.  This
+# is the aggressive-maintenance mode selfmon exists to exercise.
+#
+# --prune shrinks the control table's logical ROW count, which compaction
+# alone never does: compaction merges add-files but the append-only
+# lifecycle log grows ~3-6 rows per transaction forever.  Pruning deletes
+# replicated history at/below a safe horizon in this same checkpoint +
+# vacuum pass.  selfmon has no push remote, so --allow-no-remote enables
+# retention-only pruning: keep the most recent --keep-txns transactions.
+# Pruned history is unrecoverable, which is fine for selfmon.
+#
+# --collapse-versions 100 collapses data:series files with >100 live
+# versions; the threshold self-gates.
+"${PONDBIN}" maintain --compact --collapse-versions 100 \
+    --prune --allow-no-remote --keep-txns 1000 \
+    || echo "WARNING: pre-tick maintain failed" >&2
+
 # Bootstrap: on first run there is no journal cursor, and journalctl
 # would dump the entire host history at once, blowing the binary's
 # 3GiB allocation cap.  Seed the cursor at "now" so we ingest only
@@ -117,9 +154,13 @@ for envf in "${BASE_DIR}/env"/*.env; do
         echo "WARNING: measure-pond.sh ${pond_name} failed" >&2
 done
 
-# Ingest external sources.
-"${PONDBIN}" run /system/etc/journal push
-"${PONDBIN}" run /system/etc/caddy-access push
+# Ingest external sources.  Non-fatal: a transient failure in one source
+# must not abort the tick before the pre-sitegen maintain runs, which is
+# what historically let uncheckpointed versions pile up and wedge the pond.
+"${PONDBIN}" run /system/etc/journal push \
+    || echo "WARNING: journal ingest failed" >&2
+"${PONDBIN}" run /system/etc/caddy-access push \
+    || echo "WARNING: caddy-access ingest failed" >&2
 
 # Ingest per-pond perf jsonl.  One mknod per pond + _self because
 # logfile-ingest selects exactly ONE active file per mknod.  Mknods
@@ -143,29 +184,9 @@ if [ -d "${TEMPLATE_SRC}" ]; then
     done
 fi
 
-# Maintain every tick: checkpoint + vacuum (gated internally), compact
-# small parquet files, and collapse data:series files with >100 live
-# versions (threshold self-gates).
-#
-# --compact runs every tick on purpose.  The control table gains one
-# small record-parquet per control commit and is otherwise NEVER merged
-# (post-commit auto-maintain and a plain `pond maintain` both pass
-# compact=false), so without per-tick compaction its add-file count grows
-# without bound and every force=true checkpoint must re-list all of them,
-# bloating {POND}/control to many GB of checkpoint parquets.  Compacting
-# each tick keeps the control add-file count -- and therefore checkpoint
-# size -- bounded, which also keeps default log retention harmless.  This
-# is the aggressive-maintenance mode selfmon exists to exercise.
-#
-# --prune shrinks the control table's logical ROW count, which compaction
-# alone never does: compaction merges add-files but the append-only
-# lifecycle log grows ~3-6 rows per transaction forever.  Pruning deletes
-# replicated history at/below a safe horizon in this same checkpoint +
-# vacuum pass.  selfmon has no push remote, so --allow-no-remote enables
-# retention-only pruning (keep the most recent --keep-txns transactions;
-# pruned history is unrecoverable, which is fine for selfmon).
-"${PONDBIN}" maintain --compact --collapse-versions 100 \
-    --prune --allow-no-remote --keep-txns 1000
+# Maintenance already ran at the top of this tick; sitegen reads the pond
+# as-is.  The few versions appended since that pass are collapsed by the
+# next tick's pre-tick maintain.
 
 # Sitegen render, with wall-clock timing.  Output dir is owned by
 # ${USER} (provisioned by terraform) and served by Caddy at /selfmon/.

--- a/config/scripts/run.sh
+++ b/config/scripts/run.sh
@@ -20,6 +20,15 @@ fi
 TYPE="${INSTANCE%-staging}"
 TYPE="${TYPE%-prod}"
 
+# Refresh the container image once per tick.  pond.sh uses --pull=missing for
+# the per-command runs below, so without this the image would never update on a
+# timer tick; with it, exactly one registry check happens per tick (instead of
+# one per sub-command).  Selfmon runs natively and has no image.
+case "${TYPE}" in
+    *selfmon) : ;;
+    *) ${EXE} "${INSTANCE}" --pull-image ;;
+esac
+
 case "${TYPE}" in
     noyo)
         ${EXE} "${INSTANCE}" run /laketech/data pull

--- a/config/scripts/run.sh
+++ b/config/scripts/run.sh
@@ -59,6 +59,14 @@ case "${TYPE}" in
         TIMESTAMP=$(date +%Y%m%d-%H%M%S)
         DEPLOY_DIR="${DEPLOY_BASE}/build-${TIMESTAMP}"
         mkdir -p "${DEPLOY_DIR}"
+        # Seed the new build's data/ from the previous build so the sitegen
+        # export can reconcile per-partition: unchanged partitions are reused
+        # (hardlinked) and only changed partitions are rewritten. Hardlinks are
+        # safe because the export publishes rewritten partitions via
+        # temp-then-rename, never modifying a shared inode in place.
+        if [ -d "${DEPLOY_BASE}/current/data" ]; then
+            cp -al "${DEPLOY_BASE}/current/data" "${DEPLOY_DIR}/data"
+        fi
         SITE_BUILD_DIR="${DEPLOY_DIR}" ${EXE} "${INSTANCE}" run /system/etc/90-sitegen build /www
         ln -sfn "${DEPLOY_DIR}" "${DEPLOY_BASE}/current"
         # Clean old builds (keep last 3)
@@ -67,6 +75,9 @@ case "${TYPE}" in
         if [[ "${INSTANCE}" == *-prod ]] && [ -n "${CLOUD_HOST}" ]; then
             CLOUD_WWW="/home/jmacd/duckpond/www"
             CLOUD_BUILD="${CLOUD_WWW}/build-${TIMESTAMP}"
+            # Seed the remote build from the current one so rsync transfers only
+            # changed partition files rather than the whole tree every tick.
+            ssh "${CLOUD_HOST}" "mkdir -p '${CLOUD_BUILD}'; if [ -d '${CLOUD_WWW}/current' ]; then cp -al \"\$(readlink -f '${CLOUD_WWW}/current')/.\" '${CLOUD_BUILD}/'; fi"
             rsync -az --delete "${DEPLOY_DIR}/" "${CLOUD_HOST}:${CLOUD_BUILD}/"
             ssh "${CLOUD_HOST}" "ln -sfn '${CLOUD_BUILD}' '${CLOUD_WWW}/current' && ls -dt '${CLOUD_WWW}'/build-* | tail -n +4 | xargs rm -rf"
         fi

--- a/statements/proposals/noyo-data-collection-proposal.md
+++ b/statements/proposals/noyo-data-collection-proposal.md
@@ -1,0 +1,93 @@
+# Proposal: Onsite Water-Quality Data Collection for Noyo Marine Center
+
+> **Prepared for:** Noyo Marine Center — Noyo Harbor water-quality monitoring project
+> **Prepared by:** Joshua MacDonald — volunteer; Principal Software Engineer, Microsoft; owner/operator, Caspar Water Company
+> **Date:** 2026-06-28
+> **Status:** Hardware purchase proposal
+
+## Summary
+
+Noyo Marine Center currently collects water-quality data from two
+multi-parameter probes located at its Field Station dock. These probes
+were funded through Noyo Harbor Blue Economy project grants, and they
+are being operated by the Noyo Marine Center to monitor conditions
+for onsite aquatic life.
+
+This proposal asks Noyo Marine Center to purchase a low-cost computer
+to connect directly by cable to the two probes. The hardware will run
+open-source software built by Caspar Water Company that is designed to
+collect, backup and publish small-scale telemetry data. The proposed
+hardware will eliminate subscription costs and produce a public portal
+for sharing water quality data on the Noyo Marine Center website.
+
+## Background
+
+The water quality data being collected is sent over the cellular
+network to a software service maintained by the manufacturer, carrying
+recurring subscription fees. The probes measure disolved oxygen,
+salinity, water temperature, and pressure. While three probes were
+originally purchased for the study, one was removed from service.
+
+## Engineering
+
+Joshua is a Principal Software Engineer at Microsoft with a specialty
+in open-source telemetry systems. He is a member of the OpenTelemetry
+technical committee, an industry association under the Linux-foundation
+responsible for software telemetry protocols.
+
+Joshua became the owner/operator of Caspar Water Company in 2021 and
+began building a small-scale, low-cost "operating system" for use by
+small water systems. He has been volunteering on this effort since the
+Noyo Harbor Blue Economy project formed with Jami Miller.
+
+## Detailed design
+
+### Computer
+
+The selected computer will be a [Beagle Play single-board
+computer](https://www.beagleboard.org/boards/beagleplay), designed by
+the BeagleBoard foundation. It is an open-source hardware design
+running the Linux operating system. This model features a number of
+wireless connectivity options which could be used to collect
+
+We will add a Sandisk 128GB MAX Endurance microSDXC.
+
+### Communications
+
+The In-Situ AT500 probes are designed with support for multiple
+communictation protocols. The simplest and least expensive choice for
+Noyo Marine Center is the Modbus protocol using RS-485 communication.
+
+The RS-485 protocol will be added to the computer using a [Mikroe
+RS485 Click 3.3V add-on board](https://www.mikroe.com/rs485-33v-click).
+
+### Power
+
+The computer and accessories will be powered through a standard 120V
+outlet using two AC:DC power supplies, Mean Well HDR-15-24 for the
+probes and HDR-30-5 for the computer.
+
+The system will draw up to 25W of power, approximately 0.6kW daily,
+220 kW or approximately $100 yearly to operate.
+
+### Cabling
+
+In-Situ cables are expensive and sold by the foot. It appears
+that Noyo Marine Center has long-enough cable
+
+https://in-situ.com/us/rugged-cable-splitter
+
+
+
+
+## Bill of materials
+
+Beagle Play $101
+Mikroe RS485 Click 3.3V $22
+Sandisk 128GB MAX Endurance microSDXC $57
+Mean Well MDR-30-5 $20
+Mean Well MDR-15-24 $20
+Enclosure
+Wire, DIN-rail, mounting, terminal blocks, clock battery. $50
+
+

--- a/statements/proposals/noyo-data-collection-proposal.md
+++ b/statements/proposals/noyo-data-collection-proposal.md
@@ -14,18 +14,16 @@ are being operated by the Noyo Marine Center to monitor conditions
 for onsite aquatic life.
 
 This proposal asks Noyo Marine Center to purchase a low-cost computer
-to connect directly by cable to the two probes. The hardware will run
-open-source software built by Caspar Water Company that is designed to
-collect, backup and publish small-scale telemetry data. The proposed
-hardware will eliminate subscription costs and produce a public portal
-for sharing water quality data on the Noyo Marine Center website.
+to connect directly by cable to the two probes. The proposed hardware
+will eliminate subscription costs and produce a public portal for
+sharing water quality data on the Noyo Marine Center website.
 
 ## Background
 
 The water quality data being collected is sent over the cellular
 network to a software service maintained by the manufacturer, carrying
 recurring subscription fees. The probes measure disolved oxygen,
-salinity, water temperature, and pressure. While three probes were
+salinity, water temperature, and tide level. While three probes were
 originally purchased for the study, one was removed from service.
 
 ## Engineering
@@ -40,6 +38,24 @@ began building a small-scale, low-cost "operating system" for use by
 small water systems. He has been volunteering on this effort since the
 Noyo Harbor Blue Economy project formed with Jami Miller.
 
+## Open-Source Software
+
+Open-source software is software whose underlying source code is
+licensed for public use, allowing anyone to view, modify, share, and
+redistribute their work. Caspar Water Company is developing
+open-source software to support data collection in small-scale
+industrial and environmental monitoring applications.
+
+The software, named Duckpond, provides a complete platform for
+collecting, archiving and publishing telemetry data to a public
+portal. Duckpond designed to operate at low cost with flexible options
+for off-site storage.
+
+Open-source software is popular with users for avoiding vendor
+lock-in. Becuse open-source software is available to the public, Noyo
+Marine Center will be able to build and operate the software itself,
+should it become necessary for any reason.
+
 ## Detailed design
 
 ### Computer
@@ -50,7 +66,7 @@ the BeagleBoard foundation. It is an open-source hardware design
 running the Linux operating system. This model features a number of
 wireless connectivity options which could be used to collect
 
-We will add a Sandisk 128GB MAX Endurance microSDXC.
+We will add a 128GB microSD card for local storage.
 
 ### Communications
 
@@ -82,12 +98,42 @@ https://in-situ.com/us/rugged-cable-splitter
 
 ## Bill of materials
 
-Beagle Play $101
-Mikroe RS485 Click 3.3V $22
-Sandisk 128GB MAX Endurance microSDXC $57
-Mean Well MDR-30-5 $20
-Mean Well MDR-15-24 $20
-Enclosure
-Wire, DIN-rail, mounting, terminal blocks, clock battery. $50
+Approximate single-unit prices, USD, excluding tax and shipping. Three
+small orders: the compute parts, the power supplies, and one
+AutomationDirect order that covers the enclosure and all panel wiring.
 
+**Compute** — *SparkFun / DigiKey / Mouser*
+
+| Part | Part number | Qty | Price |
+|------|-------------|----:|------:|
+| BeaglePlay single-board computer | BeaglePlay | 1 | $101 |
+| Mikroe RS485 Click, 3.3 V | MIKROE-986 | 1 | $22 |
+| SanDisk 128GB MAX Endurance microSDXC | SDSQQVR-128G | 1 | $57 |
+
+**Power** — *DigiKey / Mouser*
+
+| Part | Part number | Qty | Price |
+|------|-------------|----:|------:|
+| Mean Well 5 V DIN supply (computer) | HDR-30-5 | 1 | $20 |
+| Mean Well 24 V DIN supply (probes) | HDR-15-24 | 1 | $20 |
+
+**Enclosure and panel wiring** — *all from [AutomationDirect](https://www.automationdirect.com) in one order*
+
+| Part | Part number | Qty | Price |
+|------|-------------|----:|------:|
+| Steel enclosure, NEMA 1 indoor, ~10×8×4 in, screw cover[^enc] | B100804 | 1 | $30 |
+| Steel back panel (DIN backing plate) | SPB1008 | 1 | $12 |
+| DIN rail, 35 mm steel, 1 m (cut to fit) | DN-R35S1 | 1 | $8 |
+| DIN-rail end brackets | DN-EB35 | 2 | $2 |
+| Feed-through terminal blocks, 12 AWG | DN-T12 | 6 | $6 |
+| Ground terminal block (green/yellow) | DN-G12 | 2 | $4 |
+| Enclosure grounding lug kit (any 10–14 AWG panel-bond lug) | — | 1 | $6 |
+| DIN-rail mount for the BeaglePlay (C45 snap clips + M3 nylon standoffs, from Amazon) | — | 1 | $8 |
+| Fasteners (M4 screws for rail, panel studs are included) | — | 1 | $4 |
+
+**Approximate total: ~$300**
+
+[^enc]: This is an indoor NEMA 1 enclosure that protects the hardware in a
+sheltered location. Exterior or wash-down placement would require a weather-rated
+enclosure (e.g. a NEMA 4X polycarbonate box), at higher cost.
 

--- a/statements/proposals/noyo-data-collection-proposal.md
+++ b/statements/proposals/noyo-data-collection-proposal.md
@@ -8,70 +8,68 @@
 ## Summary
 
 Noyo Marine Center currently collects water-quality data from two
-multi-parameter probes located at its Field Station dock. These probes
-were funded through Noyo Harbor Blue Economy project grants, and they
-are being operated by the Noyo Marine Center to monitor conditions
-for onsite aquatic life.
+multi-parameter probes located at its Field Station dock originally
+funded through grants to Noyo Ocean Collective.
 
-This proposal asks Noyo Marine Center to purchase a low-cost computer
-to connect directly by cable to the two probes. The proposed hardware
-will eliminate subscription costs and produce a public portal for
-sharing water quality data on the Noyo Marine Center website.
+This proposes that Noyo Marine Center purchase computer equipment to
+operate the probes directly and to publish its water quality data
+to the Noyo Marine Center website.
 
 ## Background
 
-The water quality data being collected is sent over the cellular
-network to a software service maintained by the manufacturer, carrying
-recurring subscription fees. The probes measure disolved oxygen,
-salinity, water temperature, and tide level. While three probes were
-originally purchased for the study, one was removed from service.
+The water quality probes currently transmit over the cellular
+telephone network and public internet to servers operated by the
+manufacturer, making them relatively expensive to operate.
+
+The probes measure dissolved oxygen, salinity, water temperature, and
+tide level. While three probes were originally purchased for the
+study, one was removed from service.
 
 ## Engineering
 
 Joshua is a Principal Software Engineer at Microsoft with a specialty
 in open-source telemetry systems. He is a member of the OpenTelemetry
-technical committee, an industry association under the Linux-foundation
-responsible for software telemetry protocols.
+technical committee, an industry association under the Linux
+foundation responsible for software telemetry protocols.
 
-Joshua became the owner/operator of Caspar Water Company in 2021 and
-began building a small-scale, low-cost "operating system" for use by
-small water systems. He has been volunteering on this effort since the
-Noyo Harbor Blue Economy project formed with Jami Miller.
+Joshua became the owner/operator of Caspar Water Company in 2021, when
+he began to create open-source software to manage operations at Caspar
+Water Company as a way to lower cost for users.
 
 ## Open-Source Software
 
 Open-source software is software whose underlying source code is
 licensed for public use, allowing anyone to view, modify, share, and
-redistribute their work. Caspar Water Company is developing
-open-source software to support data collection in small-scale
-industrial and environmental monitoring applications.
+redistribute the original work. After learning about Noyo Harbor Blue
+Economy project in 2024, Joshua began developing software to download
+data from the manufacturer's website and publish it to a portal.
 
-The software, named Duckpond, provides a complete platform for
-collecting, archiving and publishing telemetry data to a public
-portal. Duckpond designed to operate at low cost with flexible options
-for off-site storage.
+Today, the software is a complete platform for collecting, archiving
+and publishing telemetry data. Duckpond is designed to operate at low
+cost, with flexible options for off-site storage.
 
 Open-source software is popular with users for avoiding vendor
-lock-in. Becuse open-source software is available to the public, Noyo
-Marine Center will be able to build and operate the software itself,
-should it become necessary for any reason.
+"lock-in". Because this software is licensed to the public, Noyo
+Marine Center will be able to build and operate the software itself if
+for any reason Joshua is no longer able to volunteer.
 
 ## Detailed design
 
 ### Computer
 
-The selected computer will be a [Beagle Play single-board
+The recommended computer is a [Beagle Play single-board
 computer](https://www.beagleboard.org/boards/beagleplay), designed by
 the BeagleBoard foundation. It is an open-source hardware design
 running the Linux operating system. This model features a number of
-wireless connectivity options which could be used to collect
+wireless connectivity options which could be used to collect from
+remote sensors across the harbor in the future.
 
 We will add a 128GB microSD card for local storage.
 
 ### Communications
 
 The In-Situ AT500 probes are designed with support for multiple
-communictation protocols. The simplest and least expensive choice for
+communication protocols. The simplest and least expensive choice for
 Noyo Marine Center is the Modbus protocol using RS-485 communication.
 
 The RS-485 protocol will be added to the computer using a [Mikroe
@@ -88,8 +86,9 @@ The system will draw up to 25W of power, approximately 0.6kW daily,
 
 ### Cabling
 
-In-Situ cables are expensive and sold by the foot. It appears
-that Noyo Marine Center has long-enough cable
+In-Situ cables are expensive and sold by the foot. It appears that
+Noyo Marine Center enough existing cable to reach the dock from a
+location inside the Field Station. 
 
 https://in-situ.com/us/rugged-cable-splitter
 

--- a/statements/proposals/noyo-data-collection-schematic.svg
+++ b/statements/proposals/noyo-data-collection-schematic.svg
@@ -1,0 +1,127 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="980" height="520" viewBox="0 0 980 520" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 z" fill="#444"/>
+    </marker>
+    <marker id="arrowR" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 z" fill="#c0392b"/>
+    </marker>
+    <marker id="arrowG" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 z" fill="#2e7d32"/>
+    </marker>
+    <style>
+      .box { fill:#ffffff; stroke:#333; stroke-width:1.5; }
+      .panel { fill:#f4f7fb; stroke:#3a6ea5; stroke-width:2; stroke-dasharray:6 4; }
+      .label { font-size:12.5px; fill:#222; }
+      .sub { font-size:11px; fill:#555; }
+      .wire { stroke:#444; stroke-width:1.6; fill:none; }
+      .pwr { stroke:#c0392b; stroke-width:2; fill:none; }
+      .pwrlbl { font-size:11px; fill:#c0392b; font-weight:bold; }
+      .datlbl { font-size:11px; fill:#1b3a5b; font-weight:bold; }
+      .net { stroke:#2e7d32; stroke-width:2; fill:none; }
+      .netlbl { font-size:11px; fill:#2e7d32; font-weight:bold; }
+    </style>
+  </defs>
+
+  <text x="490" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#1b3a5b">
+    Noyo Marine Center — Onsite Water-Quality Data Collection
+  </text>
+
+  <!-- ===== FIELD: probes ===== -->
+  <text x="110" y="72" text-anchor="middle" class="sub" font-weight="bold">In water (harbor)</text>
+
+  <rect x="20" y="90" width="180" height="60" rx="8" class="box"/>
+  <text x="110" y="114" text-anchor="middle" class="label" font-weight="bold">Aqua TROLL 500 #1</text>
+  <text x="110" y="133" text-anchor="middle" class="sub">Modbus addr A · 8–36 VDC</text>
+
+  <rect x="20" y="172" width="180" height="60" rx="8" class="box"/>
+  <text x="110" y="196" text-anchor="middle" class="label" font-weight="bold">Aqua TROLL 500 #2</text>
+  <text x="110" y="215" text-anchor="middle" class="sub">Modbus addr B · 8–36 VDC</text>
+
+  <rect x="20" y="256" width="180" height="56" rx="8" class="box" stroke-dasharray="4 3"/>
+  <text x="110" y="279" text-anchor="middle" class="sub" font-weight="bold">3rd probe / future site</text>
+  <text x="110" y="297" text-anchor="middle" class="sub">via BeaglePlay network</text>
+
+  <!-- shared RS-485 bus trunk: probes joined, then into panel -->
+  <path class="wire" d="M200,120 H230 V202 H200"/>
+  <line class="wire" x1="230" y1="120" x2="230" y2="202"/>
+  <path class="wire" d="M230,161 H295" marker-end="url(#arrow)"/>
+  <text x="262" y="138" text-anchor="middle" class="datlbl">RS-485</text>
+  <text x="262" y="153" text-anchor="middle" class="sub">Modbus RTU</text>
+  <text x="262" y="178" text-anchor="middle" class="sub">120 Ω · 19200 8N1</text>
+
+  <!-- ===== ENCLOSURE PANEL ===== -->
+  <rect x="300" y="84" width="450" height="368" rx="10" class="panel"/>
+  <text x="525" y="106" text-anchor="middle" class="sub" font-weight="bold" fill="#3a6ea5">
+    DIN-rail enclosure (wall-mounted)
+  </text>
+
+  <!-- AC-DC supply -->
+  <rect x="325" y="124" width="185" height="58" rx="8" class="box"/>
+  <text x="417" y="148" text-anchor="middle" class="label" font-weight="bold">24 VDC supply</text>
+  <text x="417" y="166" text-anchor="middle" class="sub">DIN-rail AC-DC, 15–30 W</text>
+
+  <!-- buck -->
+  <rect x="555" y="124" width="170" height="58" rx="8" class="box"/>
+  <text x="640" y="148" text-anchor="middle" class="label" font-weight="bold">24→5 V buck</text>
+  <text x="640" y="166" text-anchor="middle" class="sub">USB-C, 5 V / 3 A</text>
+
+  <!-- RS485 click -->
+  <rect x="325" y="320" width="185" height="58" rx="8" class="box"/>
+  <text x="417" y="344" text-anchor="middle" class="label" font-weight="bold">RS485 Click</text>
+  <text x="417" y="362" text-anchor="middle" class="sub">mikroBUS, 3.3 V</text>
+
+  <!-- beagleplay -->
+  <rect x="555" y="250" width="170" height="170" rx="8" class="box"/>
+  <text x="640" y="275" text-anchor="middle" class="label" font-weight="bold">BeaglePlay</text>
+  <text x="640" y="293" text-anchor="middle" class="sub">TI AM625 · Linux</text>
+  <line x1="571" y1="304" x2="709" y2="304" stroke="#ccc"/>
+  <text x="640" y="324" text-anchor="middle" class="sub" font-weight="bold">Duckpond</text>
+  <text x="640" y="342" text-anchor="middle" class="sub">OS: 16 GB eMMC</text>
+  <text x="640" y="360" text-anchor="middle" class="sub">data: high-endurance microSD</text>
+  <text x="640" y="385" text-anchor="middle" class="sub">Eth · Wi-Fi · sub-GHz</text>
+  <text x="640" y="403" text-anchor="middle" class="sub">(harbor expansion)</text>
+
+  <!-- AC mains in -->
+  <path class="pwr" d="M417,84 V124" marker-end="url(#arrowR)"/>
+  <text x="427" y="79" class="pwrlbl">AC mains</text>
+
+  <!-- 24V to probes (down, out left of panel, up to probes) -->
+  <path class="pwr" d="M325,153 H285 V350 H110 V232" marker-end="url(#arrowR)"/>
+  <text x="250" y="343" text-anchor="middle" class="pwrlbl">24 VDC → probe power</text>
+
+  <!-- 24V to buck -->
+  <path class="pwr" d="M510,153 H555" marker-end="url(#arrowR)"/>
+  <text x="532" y="146" text-anchor="middle" class="pwrlbl">24 V</text>
+
+  <!-- buck to beagleplay USB-C -->
+  <path class="pwr" d="M640,182 V250" marker-end="url(#arrowR)"/>
+  <text x="678" y="220" text-anchor="middle" class="pwrlbl">5 V USB-C</text>
+
+  <!-- RS485 click to beagleplay UART -->
+  <path class="wire" d="M510,349 H555" marker-end="url(#arrow)"/>
+  <text x="532" y="342" text-anchor="middle" class="datlbl">UART</text>
+
+  <!-- ===== INTERNET / PORTAL ===== -->
+  <rect x="800" y="250" width="160" height="62" rx="8" class="box"/>
+  <text x="880" y="276" text-anchor="middle" class="label" font-weight="bold">Internet</text>
+  <text x="880" y="295" text-anchor="middle" class="sub">Ethernet / Wi-Fi</text>
+
+  <path class="net" d="M725,300 H800" marker-end="url(#arrowG)"/>
+  <text x="762" y="293" text-anchor="middle" class="netlbl">publish</text>
+
+  <rect x="800" y="360" width="160" height="62" rx="8" class="box"/>
+  <text x="880" y="386" text-anchor="middle" class="label" font-weight="bold">Public portal</text>
+  <text x="880" y="405" text-anchor="middle" class="sub">casparwater.us/noyo-harbor</text>
+
+  <path class="net" d="M880,312 V360" marker-end="url(#arrowG)"/>
+
+  <!-- legend -->
+  <line class="pwr" x1="20" y1="478" x2="55" y2="478"/>
+  <text x="62" y="482" class="sub">power (DC)</text>
+  <line class="wire" x1="150" y1="478" x2="185" y2="478"/>
+  <text x="192" y="482" class="sub">RS-485 / UART data</text>
+  <line class="net" x1="330" y1="478" x2="365" y2="478"/>
+  <text x="372" y="482" class="sub">network</text>
+  <text x="455" y="482" class="sub">Excluded: In-Situ probe cables / RS-485 adapters; site internet link.  Software, install &amp; operation: donated.</text>
+</svg>

--- a/terraform/station/watershop/watershop.tf
+++ b/terraform/station/watershop/watershop.tf
@@ -82,10 +82,22 @@ locals {
     }
     watershop-selfmon = {
       s3         = local.staging_s3
+      # s3_url provisions a MinIO bucket and the S3_* env used to resolve
+      # credentials, but attach-remotes.sh intentionally does NOT attach a
+      # backup remote for selfmon: run-selfmon.sh prunes aggressively with
+      # --allow-no-remote, which is incompatible with a push backup because
+      # the post-commit push reads already-vacuumed files and holds the
+      # write.lock, blocking compaction.  The bucket therefore stays
+      # unused; kept only so the reset path can still empty it.
       s3_url     = "s3://watershop-selfmon"
       interval   = "1min"
       boot_delay = "30s"
-      extra_env  = "SELFMON=1"
+      # POND_MEMORY_LIMIT_MB raises the tlogfs FairSpillPool above its
+      # 512MiB default so resolving /logs/journal, which holds hundreds of
+      # per-unit jsonl files, has room for its ~207MiB external sort instead
+      # of OOMing.  Requires a pond binary built on or after 2026-06-30,
+      # commit a84fb9bc; older binaries ignore this and stay at 512MiB.
+      extra_env  = "SELFMON=1\nPOND_MEMORY_LIMIT_MB=2048"
       selfmon    = true
     }
   }

--- a/terraform/station/watershop/watershop.tf
+++ b/terraform/station/watershop/watershop.tf
@@ -367,6 +367,12 @@ resource "null_resource" "watershop" {
           "echo '[reset] ${name}: done'",
         ])
       ],
+      # Refresh the container image once at deploy time.  pond.sh now uses
+      # --pull=missing, so a terraform apply after a new image is promoted must
+      # explicitly pull it; timer ticks then keep it current via --pull-image.
+      [for name in local.container_instance_names :
+        "${local.base_dir}/config/scripts/pond.sh ${name} --pull-image"
+      ],
       # Initialize containerized instances if not already initialized.
       # `pond init` errors with "Pond already exists" on a populated pond;
       # we detect that condition on the host (via the volume's mountpoint)


### PR DESCRIPTION
## Summary

Operational fixes for the watershop staging/selfmon deployment, deploy-script
tuning, and the Noyo data-collection proposal.

### Deployment / selfmon
- **Repair selfmon OOM crash-loop**: run `maintain` first each tick, drop the
  backup remote, raise the memory limit.
- **Fix selfmon self-card false-red**: probe the `pond-selfmon@` units instead
  of the nonexistent `pond@<instance>` units.
- **run.sh**: seed the new site build dir from `current/data` so the sitegen
  export can reconcile per-partition (hardlink-reuse unchanged partitions,
  rewrite only changed ones) -- complements the duckpond #100 export fix.
- **deploy**: pull the duckpond image once per tick (`--pull-image`) rather than
  once per sub-command, to avoid redundant GHCR checks.
- Duckpond image bumps (overlay chart "Explore this data" pivot).

### Proposal
- `statements/proposals/noyo-data-collection-proposal.md`: onsite water-quality
  data-collection proposal for Noyo Marine Center.
