### PR TITLE
watershop: fail terraform apply if install-watertown.sh fails

### DIFF
--- a/terraform/station/watershop/watershop.tf
+++ b/terraform/station/watershop/watershop.tf
@@ -302,8 +302,12 @@ resource "null_resource" "watershop" {
       # tools/build-on-watershop.sh).  Always installs the newest .deb
       # in target/debian/; selfmon is local-experimental, no version
       # pinning.  Skipped if there is no selfmon instance to run.
+      # `|| exit 1` because remote-exec runs the whole inline list as one
+      # shell WITHOUT `set -e`; without it a failed deb install (the
+      # script exits non-zero) is masked by later commands and the apply
+      # wrongly reports success.
       length(local.selfmon_instance_names) > 0
-      ? ["${local.base_dir}/config/scripts/install-watertown.sh"]
+      ? ["${local.base_dir}/config/scripts/install-watertown.sh || exit 1"]
       : [],
       # Provision per-instance metrics dir (writable by the user that
       # runs the selfmon timer).


### PR DESCRIPTION
## Problem
The selfmon deb-install step is one element of a `remote-exec` `inline` list, which terraform runs as a single shell **without** `set -e`. A non-zero exit from `install-watertown.sh` is therefore masked by the commands that follow it, and the apply reports success even though the deb never installed.

Observed during the watertown staging migration: `install-watertown.sh` failed (`dpkg` refused to overwrite `/usr/bin/pond` owned by the old `duckpond` package) yet `terraform apply` printed `Apply complete!`, leaving the stale binary in place.

## Fix
Append `|| exit 1` to the install invocation so the shell aborts immediately and terraform surfaces the provisioner failure.

## Related
Companion watertown PR jmacd/watertown#104 adds `Conflicts`/`Replaces: duckpond` to the deb so the overwrite that triggered this no longer happens on hosts still carrying the legacy package.