### PR TITLE
selfmon: hourly auto-update from ghcr pond-deb OCI artifact

### DIFF
--- a/config/scripts/cleanup-stale-pond-units.sh
+++ b/config/scripts/cleanup-stale-pond-units.sh
@@ -25,11 +25,11 @@ is_kept() {
 
 KEEP=("$@")
 
-systemctl --user list-units --all --no-legend 'pond@*.timer' 'pond-selfmon@*.timer' 2>/dev/null \
+systemctl --user list-units --all --no-legend 'pond@*.timer' 'pond-selfmon@*.timer' 'pond-selfmon-update@*.timer' 2>/dev/null \
     | awk '{print $1}' \
     | while read -r unit; do
         # Strip prefix and .timer suffix to recover the instance name.
-        name=$(echo "$unit" | sed -E 's/^pond(-selfmon)?@(.*)\.timer$/\2/')
+        name=$(echo "$unit" | sed -E 's/^pond(-selfmon(-update)?)?@(.*)\.timer$/\3/')
         if ! is_kept "$name" "${KEEP[@]}"; then
             echo "Disabling stale unit: $unit (name=$name)"
             systemctl --user disable --now "$unit" 2>/dev/null || true
@@ -40,14 +40,18 @@ systemctl --user list-units --all --no-legend 'pond@*.timer' 'pond-selfmon@*.tim
 shopt -s nullglob
 for f in "$HOME/.config/systemd/user"/pond@*.timer \
          "$HOME/.config/systemd/user"/pond-selfmon@*.timer \
+         "$HOME/.config/systemd/user"/pond-selfmon-update@*.timer \
          "$HOME/.config/systemd/user"/pond@*.service \
-         "$HOME/.config/systemd/user"/pond-selfmon@*.service; do
+         "$HOME/.config/systemd/user"/pond-selfmon@*.service \
+         "$HOME/.config/systemd/user"/pond-selfmon-update@*.service; do
     base=$(basename "$f")
-    # pond@.service / pond-selfmon@.service are the templates -- keep them.
+    # pond@.service / pond-selfmon@.service / pond-selfmon-update@.{service,timer}
+    # are the templates -- keep them.
     case "$base" in
         pond@.service|pond-selfmon@.service) continue ;;
+        pond-selfmon-update@.service|pond-selfmon-update@.timer) continue ;;
     esac
-    name=$(echo "$base" | sed -E 's/^pond(-selfmon)?@(.*)\.(timer|service)$/\2/')
+    name=$(echo "$base" | sed -E 's/^pond(-selfmon(-update)?)?@(.*)\.(timer|service)$/\3/')
     if ! is_kept "$name" "${KEEP[@]}"; then
         echo "Removing stale unit file: $base (name=$name)"
         rm -f "$f"

--- a/config/scripts/install-oras.sh
+++ b/config/scripts/install-oras.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# install-oras.sh -- install a pinned `oras` binary to /usr/local/bin.
+#
+# Idempotent: a no-op if the pinned version is already present.  Used by the
+# selfmon deb auto-update path: update-selfmon.sh pulls the pond .deb OCI
+# artifact (ghcr.io/jmacd/watertown/pond-deb) with oras.  The version and
+# checksums are pinned to avoid supply-chain drift; bump them together with
+# the ORAS_VERSION env in the watertown repo's rust-ci.yml so the box and CI
+# agree on the tool that pushes/pulls the artifact.
+set -euo pipefail
+
+ORAS_VERSION="${ORAS_VERSION:-1.3.2}"
+SHA_AMD64="9229ccc6d17bb282039ad4a69abb16dcb887a5bce567c075d731d9b3c7ad8eaf"
+SHA_ARM64="8db4a223bd6034deff198e791ea7cb3af0840df25b7e9f370e2f1f3fd20d389b"
+
+case "$(uname -m)" in
+    aarch64|arm64) ARCH="arm64"; SHA="${SHA_ARM64}" ;;
+    x86_64|amd64)  ARCH="amd64"; SHA="${SHA_AMD64}" ;;
+    *) echo "install-oras: unsupported arch $(uname -m)" >&2; exit 1 ;;
+esac
+
+if command -v oras >/dev/null 2>&1 && oras version 2>/dev/null | grep -q "${ORAS_VERSION}"; then
+    echo "install-oras: oras ${ORAS_VERSION} already installed"
+    exit 0
+fi
+
+TARBALL="oras_${ORAS_VERSION}_linux_${ARCH}.tar.gz"
+TMP=$(mktemp -d)
+trap 'rm -rf "${TMP}"' EXIT
+
+curl -fsSL -o "${TMP}/${TARBALL}" \
+    "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/${TARBALL}"
+echo "${SHA}  ${TMP}/${TARBALL}" | sha256sum -c -
+tar -xzf "${TMP}/${TARBALL}" -C "${TMP}" oras
+sudo install -m 0755 "${TMP}/oras" /usr/local/bin/oras
+/usr/local/bin/oras version

--- a/config/scripts/install-oras.sh
+++ b/config/scripts/install-oras.sh
@@ -19,7 +19,7 @@ case "$(uname -m)" in
     *) echo "install-oras: unsupported arch $(uname -m)" >&2; exit 1 ;;
 esac
 
-if command -v oras >/dev/null 2>&1 && oras version 2>/dev/null | grep -q "${ORAS_VERSION}"; then
+if command -v oras >/dev/null 2>&1 && oras version 2>/dev/null | grep -qw "${ORAS_VERSION}"; then
     echo "install-oras: oras ${ORAS_VERSION} already installed"
     exit 0
 fi

--- a/config/scripts/update-selfmon.sh
+++ b/config/scripts/update-selfmon.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# update-selfmon.sh -- hourly auto-update of the natively-installed selfmon
+# `pond` binary from its ghcr OCI .deb artifact.
+#
+# Usage: update-selfmon.sh <instance>     (e.g. watershop-selfmon)
+#
+# Pulls ghcr.io/jmacd/watertown/pond-deb:<DEB_CHANNEL>-<arch> with oras and
+# installs it only when strictly newer than the installed `watertown` package.
+# The package is public, so the pull is anonymous.  This mirrors how container
+# ponds auto-update via `pond.sh --pull-image` on every timer tick, but on a
+# separate hourly cadence (the selfmon tick itself fires every minute, far too
+# often for a registry pull).
+#
+# Idempotent and NON-FATAL by design: a registry hiccup or a failed install
+# must never wedge the box, so every failure path warns and exits 0, leaving
+# the currently-installed binary in place (mirrors run-selfmon.sh's style).
+set -uo pipefail
+
+INSTANCE=${1:?usage: update-selfmon.sh <instance>}
+SCRIPTS=$(cd "$(dirname "$0")" && pwd)
+BASE_DIR=$(cd "${SCRIPTS}/../.." && pwd)
+ENV_FILE="${BASE_DIR}/env/${INSTANCE}.env"
+
+DEB_PACKAGE="ghcr.io/jmacd/watertown/pond-deb"
+
+# DEB_CHANNEL selects the promotion channel to track (latest vs prod).  It is
+# set per-instance in the env file; default latest, matching the selfmon
+# charter of exercising the newest code first.
+DEB_CHANNEL=latest
+if [ -f "${ENV_FILE}" ]; then
+    # shellcheck disable=SC1090
+    set -a
+    source "${ENV_FILE}"
+    set +a
+fi
+DEB_CHANNEL=${DEB_CHANNEL:-latest}
+
+case "$(uname -m)" in
+    aarch64|arm64) ARCH="arm64" ;;
+    x86_64|amd64)  ARCH="amd64" ;;
+    *) echo "update-selfmon: unsupported arch $(uname -m); skipping" >&2; exit 0 ;;
+esac
+
+if ! command -v oras >/dev/null 2>&1; then
+    echo "update-selfmon: oras not installed; skipping (run install-oras.sh)" >&2
+    exit 0
+fi
+
+REF="${DEB_PACKAGE}:${DEB_CHANNEL}-${ARCH}"
+TMP=$(mktemp -d)
+trap 'rm -rf "${TMP}"' EXIT
+
+echo "update-selfmon: pulling ${REF}"
+if ! oras pull "${REF}" --output "${TMP}"; then
+    echo "update-selfmon: oras pull failed for ${REF}; skipping" >&2
+    exit 0
+fi
+
+DEB=$(ls -t "${TMP}"/watertown_*_"${ARCH}".deb 2>/dev/null | head -1)
+if [ -z "${DEB}" ] || [ ! -f "${DEB}" ]; then
+    echo "update-selfmon: no watertown_*_${ARCH}.deb in pulled artifact; skipping" >&2
+    exit 0
+fi
+
+NEW_VER=$(dpkg-deb -f "${DEB}" Version)
+INSTALLED=$(dpkg-query -W -f='${Version}' watertown 2>/dev/null || echo "")
+
+if [ -n "${INSTALLED}" ] && dpkg --compare-versions "${NEW_VER}" le "${INSTALLED}"; then
+    echo "update-selfmon: installed ${INSTALLED} >= pulled ${NEW_VER} (${DEB_CHANNEL}); no-op"
+    exit 0
+fi
+
+echo "update-selfmon: installing $(basename "${DEB}") (${INSTALLED:-none} -> ${NEW_VER})"
+if ! sudo dpkg -i "${DEB}"; then
+    echo "update-selfmon: dpkg -i failed; leaving previous binary in place" >&2
+    exit 0
+fi
+/usr/bin/pond --version 2>/dev/null || true

--- a/config/scripts/update-selfmon.sh
+++ b/config/scripts/update-selfmon.sh
@@ -62,7 +62,11 @@ if [ -z "${DEB}" ] || [ ! -f "${DEB}" ]; then
     exit 0
 fi
 
-NEW_VER=$(dpkg-deb -f "${DEB}" Version)
+NEW_VER=$(dpkg-deb -f "${DEB}" Version 2>/dev/null || echo "")
+if [ -z "${NEW_VER}" ]; then
+    echo "update-selfmon: could not read version from ${DEB}; skipping" >&2
+    exit 0
+fi
 INSTALLED=$(dpkg-query -W -f='${Version}' watertown 2>/dev/null || echo "")
 
 if [ -n "${INSTALLED}" ] && dpkg --compare-versions "${NEW_VER}" le "${INSTALLED}"; then

--- a/config/systemd/pond-selfmon-update@.service
+++ b/config/systemd/pond-selfmon-update@.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Watertown selfmon deb auto-update %i (native)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/home/jmacd/watertown/config/scripts/update-selfmon.sh %i
+Environment=HOME=/home/jmacd

--- a/config/systemd/pond-selfmon-update@.timer
+++ b/config/systemd/pond-selfmon-update@.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Watertown selfmon deb auto-update %i (hourly)
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=1h
+
+[Install]
+WantedBy=timers.target

--- a/terraform/station/watershop/watershop.tf
+++ b/terraform/station/watershop/watershop.tf
@@ -81,7 +81,7 @@ locals {
       extra_env  = "WATER_S3_URL=s3://water-pond\nNOYO_S3_URL=s3://noyo-pond\nSEPTIC_S3_URL=s3://septic-pond\nSITE_BASE_URL=/\nCLOUD_HOST=cloud"
     }
     watershop-selfmon = {
-      s3         = local.staging_s3
+      s3 = local.staging_s3
       # s3_url provisions a MinIO bucket and the S3_* env used to resolve
       # credentials, but attach-remotes.sh intentionally does NOT attach a
       # backup remote for selfmon: run-selfmon.sh prunes aggressively with
@@ -97,8 +97,8 @@ locals {
       # per-unit jsonl files, has room for its ~207MiB external sort instead
       # of OOMing.  Requires a pond binary built on or after 2026-06-30,
       # commit a84fb9bc; older binaries ignore this and stay at 512MiB.
-      extra_env  = "SELFMON=1\nPOND_MEMORY_LIMIT_MB=2048"
-      selfmon    = true
+      extra_env = "SELFMON=1\nPOND_MEMORY_LIMIT_MB=2048\nDEB_CHANNEL=latest"
+      selfmon   = true
     }
   }
 
@@ -273,6 +273,11 @@ resource "null_resource" "watershop" {
         # Install systemd unit templates (container + selfmon native)
         "cp ${local.base_dir}/config/systemd/pond@.service ${local.home}/.config/systemd/user/",
         "cp ${local.base_dir}/config/systemd/pond-selfmon@.service ${local.home}/.config/systemd/user/",
+        # Selfmon deb auto-update units (native): hourly oras pull + dpkg -i
+        # of the newest pond .deb OCI artifact.  Template units activated
+        # per selfmon instance below.
+        "cp ${local.base_dir}/config/systemd/pond-selfmon-update@.service ${local.home}/.config/systemd/user/",
+        "cp ${local.base_dir}/config/systemd/pond-selfmon-update@.timer ${local.home}/.config/systemd/user/",
         # Drop ONLY units whose instance name is no longer in the
         # configured set (e.g. retired watershop-selfmon-{staging,prod}
         # split).  Configured-but-not-deployed instances (e.g. -prod
@@ -298,6 +303,12 @@ resource "null_resource" "watershop" {
         "cp ${local.base_dir}/timers/pond-selfmon@*.timer ${local.home}/.config/systemd/user/ 2>/dev/null || true",
         "systemctl --user daemon-reload",
       ],
+      # Install the pinned `oras` client used by update-selfmon.sh to pull
+      # the pond .deb OCI artifact.  Only needed where a selfmon instance
+      # runs the hourly auto-update timer.
+      length(local.selfmon_instance_names) > 0
+      ? ["${local.base_dir}/config/scripts/install-oras.sh"]
+      : [],
       # Install the watertown .deb (built natively on watershop by
       # tools/build-on-watershop.sh).  Always installs the newest .deb
       # in target/debian/; selfmon is local-experimental, no version
@@ -445,6 +456,12 @@ resource "null_resource" "watershop" {
       ],
       [for name in local.selfmon_instance_names :
         "systemctl --user enable --now pond-selfmon@${name}.timer"
+      ],
+      # Hourly deb auto-update timer for each selfmon instance.  OnBootSec is
+      # in the past, so enable --now fires a first update check immediately
+      # and then settles onto the 1h cadence.
+      [for name in local.selfmon_instance_names :
+        "systemctl --user enable --now pond-selfmon-update@${name}.timer"
       ],
       # Site timers.  Starting a stopped site timer fires an immediate build.
       # Right after a reset the producers have pushed only their empty


### PR DESCRIPTION
Implements **Repo B** of the watertown `docs/selfmon-deb-pipeline-design.md`: the box-side half of the selfmon `.deb` auto-update pipeline. Pairs with jmacd/watertown#105 (which publishes `ghcr.io/jmacd/watertown/pond-deb`).

## Changes
- **`config/scripts/install-oras.sh`**: install a pinned `oras` client (v1.3.2, checksum-verified) to `/usr/local/bin`; idempotent.
- **`config/scripts/update-selfmon.sh`**: `oras pull` the pond `.deb` for this arch + `DEB_CHANNEL` (default `latest`), `dpkg -i` only when strictly newer than the installed `watertown` package. Non-fatal on every failure path (mirrors `run-selfmon.sh`).
- **`config/systemd/pond-selfmon-update@.{service,timer}`**: oneshot + hourly timer template (decoupled from the 1-min selfmon tick).
- **`terraform/station/watershop/watershop.tf`**: add `DEB_CHANNEL=latest` to the selfmon env, install `oras` + the update units, and enable `pond-selfmon-update@<instance>.timer`.
- **`config/scripts/cleanup-stale-pond-units.sh`**: also reap retired `pond-selfmon-update@` instance units (templates preserved).

## Notes
- Requires jmacd/watertown#105 merged so the `pond-deb` artifact exists to pull.
- Routine selfmon updates now come from CI + the hourly timer; `tools/build-on-watershop.sh` remains a dev-only fallback.
- `terraform validate` passes; `terraform fmt` clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>